### PR TITLE
Graphql handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ run `go run main.go`
 To run for prod, set `Mode="prod"` inside `config.hcl`
 then run `sudo go run main.go`
 
+## Graphql 
+
+On dev mode you can GET at `/graphql` to get graphql playground
+
 ## Architecture
 
 This can be read at `ARCHITECTURE.md`

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # GObjob
 
+**Assume everything <MAIN> or root directory**
+
 ## Setup
 
 ### Creating the config
-Inside `<MAIN>` create a copy of `config.example.hcl` named `config.hcl`
+Create a copy of `config.example.hcl` named `config.hcl`
 
 ``` sh
 $ cp config.example.hcl config.hcl
@@ -13,11 +15,12 @@ Then change the variables to whats needed
 
 ## Run
 
-Inside `<MAIN>` run `go run main.go`
+run `go run main.go`
 
 ### Run in prod
 
-To run for prod, inside `<MAIN>` run `sudo GIN_MODE=release go run main.go`
+To run for prod, set `Mode="prod"` inside `config.hcl`
+then run `sudo go run main.go`
 
 ## Architecture
 

--- a/config.example.hcl
+++ b/config.example.hcl
@@ -2,6 +2,10 @@
 // can be prod, dev, or test
 Mode = "dev"
 
+// Port: The port it runs on
+// this only matters in dev
+Port = "3000"
+
 // DB: the block to hold all database values
 DB  {
     Host="localhost"

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 // the base of the struct that the data goes into
 type Config struct {
 	Mode string   `hcl:"Mode"`
+	Port string   `hcl:"Port"`
 	DB   DBConfig `hcl:"DB,block"`
 }
 

--- a/handler/graphiql.go
+++ b/handler/graphiql.go
@@ -20,37 +20,60 @@ func (h GraphiQL) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 var graphiql = []byte(`
 <!DOCTYPE html>
 <html>
-	<head>
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.css"/>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/react/16.2.0/umd/react.production.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.2.0/umd/react-dom.production.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.min.js"></script>
-	</head>
-	<body style="width: 100%; height: 100%; margin: 0; overflow: hidden;">
-		<div id="graphiql" style="height: 100vh;">Loading...</div>
-		<script>
-			function fetchGQL(params) {
-				return fetch("/query", {
-					method: "post",
-					body: JSON.stringify(params),
-					credentials: "include",
-				}).then(function (resp) {
-					return resp.text();
-				}).then(function (body) {
-					try {
-						return JSON.parse(body);
-					} catch (error) {
-						return body;
-					}
-				});
-			}
 
-			ReactDOM.render(
-				React.createElement(GraphiQL, {fetcher: fetchGQL}),
-				document.getElementById("graphiql")
-			)
-		</script>
-	</body>
+<head>
+  <meta charset=utf-8/>
+  <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+  <title>GraphQL Playground</title>
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
+  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
+  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
+</head>
+
+<body>
+  <div id="root">
+    <style>
+      body {
+        background-color: rgb(23, 42, 58);
+        font-family: Open Sans, sans-serif;
+        height: 90vh;
+      }
+
+      #root {
+        height: 100%;
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .loading {
+        font-size: 32px;
+        font-weight: 200;
+        color: rgba(255, 255, 255, .6);
+        margin-left: 20px;
+      }
+
+      img {
+        width: 78px;
+        height: 78px;
+      }
+
+      .title {
+        font-weight: 400;
+      }
+    </style>
+    <img src='//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png' alt=''>
+    <div class="loading"> Loading
+      <span class="title">GraphQL Playground</span>
+    </div>
+  </div>
+  <script>window.addEventListener('load', function (event) {
+      GraphQLPlayground.init(document.getElementById('root'), {
+        // options as 'endpoint' belong here
+      })
+    })</script>
+</body>
+
 </html>
 `)

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 
 	// Start and run the server depending on mode
 	if gin.Mode() == gin.DebugMode {
-		log.Fatal(router.Run(":3000"))
+		log.Fatal(router.Run(":" + config.CONFIG.Port))
 	} else if gin.Mode() == gin.ReleaseMode {
 		log.Fatal(autotls.Run(router, "gibjob.engineer"))
 	}

--- a/main.go
+++ b/main.go
@@ -48,10 +48,6 @@ func main() {
 
 	schema := graphql.MustParseSchema(*schema.NewSchema(), &resolvers.Resolvers{DB: db}, opts...)
 
-	mux := http.NewServeMux()
-	mux.Handle("/graphql", handler.GraphiQL{})
-	mux.Handle("/query", handler.Authenticate(&handler.GraphQL{Schema: schema}))
-
 	// Set the router as the default one shipped with Gin
 	router := gin.Default()
 
@@ -66,6 +62,10 @@ func main() {
 	router.NoRoute(func(c *gin.Context) {
 		c.File("./frontend/public/index.html")
 	})
+
+	// graphql routes and route handling
+	router.GET("/graphql", gin.WrapH(handler.GraphiQL{}))
+	router.POST("/graphql", gin.WrapH(handler.Authenticate(&handler.GraphQL{Schema: schema})))
 
 	// Setup route group for the API
 	api := router.Group("/api")

--- a/main.go
+++ b/main.go
@@ -64,7 +64,10 @@ func main() {
 	})
 
 	// graphql routes and route handling
-	router.GET("/graphql", gin.WrapH(handler.GraphiQL{}))
+	// only enable graphql playground on dev mode
+	if gin.Mode() == gin.DebugMode {
+		router.GET("/graphql", gin.WrapH(handler.GraphiQL{}))
+	}
 	router.POST("/graphql", gin.WrapH(handler.Authenticate(&handler.GraphQL{Schema: schema})))
 
 	// Setup route group for the API

--- a/resolvers/test.go
+++ b/resolvers/test.go
@@ -1,0 +1,10 @@
+package resolvers
+
+import (
+	"context"
+)
+
+// ChangePassword mutation change password
+func (r *Resolvers) Test(ctx context.Context) (bool, error) {
+	return true, nil
+}

--- a/schema/Query/query.graphql
+++ b/schema/Query/query.graphql
@@ -1,5 +1,6 @@
 type Query {
   getMyProfile: GetMyProfileResponse!
+  test: Boolean!
 }
 type GetMyProfileResponse {
   ok: Boolean!


### PR DESCRIPTION
### What are you trying to accomplish?
to explain why this is useful, ima exaplain why the old handlers didnt work

our SPA catches routes on the backend using `NoRoute` which reserves the SPA. this is fine except it only works for gin routes, the other routes werent written with gin which is dumb.

I also added graphql playground rather than graphiql cause better ui, exporting to curl, dark theme, and its less code cause it doesnt ship with react.

i also added a test in graphql just for basic testing like this
### How are you accomplishing it?
using gin wrappers to use the handlers

for the graphql playground i just put the graphql playground html instead of graphiql

### Is there anything reviewers should know?
i setup graphql playground to only work in dev mode

### If needed, did you change documentation(`README.md`, `ARCHITECTURE.md`, etc) to reflect your changes?

- [x] Is it safe to rollback this change if anything goes wrong?
